### PR TITLE
Resolve test-data path more portably

### DIFF
--- a/tests/test_beangrep.py
+++ b/tests/test_beangrep.py
@@ -24,7 +24,7 @@ from beangrep import (
     parse_types,
 )
 
-DATA_DIR = Path(beangrep.__file__).parents[2] / "tests" / "data"
+DATA_DIR = Path(__file__).parent.resolve() / "data"
 SAMPLE_LEDGER = str(DATA_DIR / "example.beancount")
 SAMPLE_LEDGER_SMALL = str(DATA_DIR / "small.beancount")
 DIRECTIVES_IN_SAMPLE = 2247  # `bean-quey example.beancount` shows this


### PR DESCRIPTION
So it builds in non-standard environments like, e.g., a NixOS sandbox.