### PR TITLE
Enable click's auto_envvar_prefix

### DIFF
--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -23,7 +23,7 @@ from .beangrep import (
 )
 
 
-@click.command(
+@click.command(context_settings={"auto_envvar_prefix": "BEANGREP"},
     help="""Search for entries matching given criteria in Beancount journals. Pretty
 print matching entries to standard output.
 

--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -66,10 +66,14 @@ Exit status is 0 (success) if a match is found, 1 if no match is found, 2 if an 
 occurred.""",
 )
 @click.argument(
-    "args",
-    required=True,
+    "pattern",
+)
+@click.argument(
+    "filenames",
     nargs=-1,
-    metavar="[PATTERN] FILENAME...",  # override metavar to show what is required
+    required=True,
+    metavar="FILENAME",
+    envvar="BEANCOUNT_FILE"
 )
 @click.option(
     "--account",
@@ -246,7 +250,8 @@ this option once will increase it to INFO, twice or more to DEBUG.""",
 @click.pass_context
 def cli(
     ctx,
-    args,
+    pattern,
+    filenames,
     accounts,
     amounts,
     dates,
@@ -276,11 +281,6 @@ def cli(
             log_level = logging.DEBUG
     logging.basicConfig(level=log_level)
 
-    (pattern, filenames) = (None, [])
-    if len(args) == 1:  # len(args) == 0 should not happen due to required=True
-        filenames = list(args)
-    elif len(args) >= 2:
-        (pattern, filenames) = (args[0], list(args[1:]))
     if len(list(filter(lambda fname: fname == "-", filenames))) > 1:
         raise click.BadArgumentUsage(
             'Standard input ("-") cannot be specified multipled times'


### PR DESCRIPTION
Enable click's auto_envvar_prefix which allows bean-grep's command line options to also be set via environment variables.

The prefix is BEANGREP so the environment variables are BEANGREP_VERBOSE, BEANGREP_CASE_SENSITIVE, etc.

This fixes #8

n.b. I just realised I haven't updated the documentation for this but if the PR is accepted I can do that.

The environment variables could either be set permanently & globally via your shell config file or you could use something direnv to set them just while inside your beancount directory.

I think the current defaults actually work fine and don't see a need for this. However, this is scaffolding for my next pull request which will let you also specify the beancount file via an environment.