### PR TITLE
Allow options to be set via environment variables (to override defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Usage: bean-grep [OPTIONS] [PATTERN] FILENAME...
   To read from standard input, pass "-" as FILENAME, but beware that it
   implies on-disk buffering of stdin.
 
+  All options can be set via environment variables, which is most useful if
+  you want to override the defaults. Each environment variable
+  consists of the prefix BEANGREP_ followed by the option name in uppercase.
+  e.g. BEANGREP_VERBOSE, BEANGREP_CASE_SENSITIVE, BEANGREP_QUIET,
+  BEANGREP_NO_SKIP_INTERNALS, etc.
+
 Options:
   -a, --account REGEX             Only return entries referencing accounts
                                   with names matching given regex.

--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -23,7 +23,8 @@ from .beangrep import (
 )
 
 
-@click.command(context_settings={"auto_envvar_prefix": "BEANGREP"},
+@click.command(
+    context_settings={"auto_envvar_prefix": "BEANGREP"},
     help="""Search for entries matching given criteria in Beancount journals. Pretty
 print matching entries to standard output.
 

--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -23,7 +23,7 @@ from .beangrep import (
 )
 
 
-@click.command(
+@click.command(context_settings={"auto_envvar_prefix": "BEANGREP"},
     help="""Search for entries matching given criteria in Beancount journals. Pretty
 print matching entries to standard output.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,10 +253,28 @@ def test_stdin():
             == 0
         )
 
-
 def test_errors():
     runner = CliRunner()
     assert runner.invoke(cli, ["does_not_exist.beancount"]).exit_code == 2
     assert (
         runner.invoke(cli, ["--amount", "%23 USD", SAMPLE_LEDGER]).exit_code == 2
     )  # invalid amount predicate
+
+# In theory any option could be set via envvars but let's just test the
+# most likely choices
+def test_envvars():
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["--amount", "=76.81 USD", SAMPLE_LEDGER], env={"BEANGREP_QUIET": "1"})
+    assert result.exit_code == 0
+    assert "76.81 USD" not in result.output
+
+    assert (
+        runner.invoke(cli, ["-p", "boons", SAMPLE_LEDGER], env={"BEANGREP_CASE_SENSITIVE": "1"}).exit_code
+        == 1
+    )
+
+    assert (
+        runner.invoke(cli, ["-n", "software", SAMPLE_LEDGER_SMALL], env={"BEANGREP_INVERT_MATCH": "1"}).exit_code
+        == 0
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,6 +253,7 @@ def test_stdin():
             == 0
         )
 
+
 def test_errors():
     runner = CliRunner()
     assert runner.invoke(cli, ["does_not_exist.beancount"]).exit_code == 2
@@ -260,21 +261,30 @@ def test_errors():
         runner.invoke(cli, ["--amount", "%23 USD", SAMPLE_LEDGER]).exit_code == 2
     )  # invalid amount predicate
 
+
 # In theory any option could be set via envvars but let's just test the
 # most likely choices
 def test_envvars():
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["--amount", "=76.81 USD", SAMPLE_LEDGER], env={"BEANGREP_QUIET": "1"})
+    result = runner.invoke(
+        cli, ["--amount", "=76.81 USD", SAMPLE_LEDGER], env={"BEANGREP_QUIET": "1"}
+    )
     assert result.exit_code == 0
     assert "76.81 USD" not in result.output
 
     assert (
-        runner.invoke(cli, ["-p", "boons", SAMPLE_LEDGER], env={"BEANGREP_CASE_SENSITIVE": "1"}).exit_code
+        runner.invoke(
+            cli, ["-p", "boons", SAMPLE_LEDGER], env={"BEANGREP_CASE_SENSITIVE": "1"}
+        ).exit_code
         == 1
     )
 
     assert (
-        runner.invoke(cli, ["-n", "software", SAMPLE_LEDGER_SMALL], env={"BEANGREP_INVERT_MATCH": "1"}).exit_code
+        runner.invoke(
+            cli,
+            ["-n", "software", SAMPLE_LEDGER_SMALL],
+            env={"BEANGREP_INVERT_MATCH": "1"},
+        ).exit_code
         == 0
     )


### PR DESCRIPTION
Enable click's auto_envvar_prefix to fix #8 

I added a few tests and updated the README.

Let me know if you see anything else you want changed for this PR.

Cheers,
Justus