### PR TITLE
Allow passing filename via environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Usage: bean-grep [OPTIONS] [PATTERN] FILENAME...
   To read from standard input, pass "-" as FILENAME, but beware that it
   implies on-disk buffering of stdin.
 
+  The FILENAME can also be specified via the environment variable BEANCOUNT_FILE.
+  This allows not having to specify it explicitly every time bean-grep is run.
+  Only a single FILENAME is allowed to be specified this way.
+
   All options can be set via environment variables, which is most useful if
   you want to override the defaults. Each environment variable
   consists of the prefix BEANGREP_ followed by the option name in uppercase.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ Usage: bean-grep [OPTIONS] [PATTERN] FILENAME...
   To read from standard input, pass "-" as FILENAME, but beware that it
   implies on-disk buffering of stdin.
 
-  The FILENAME can also be specified via the environment variable BEANCOUNT_FILE.
-  This allows not having to specify it explicitly every time bean-grep is run.
-  Only a single FILENAME is allowed to be specified this way.
+  The FILENAME can alternatively be specified via the environment variable
+  BEANCOUNT_FILENAME. This allows not having to specify it explicitly every
+  time bean-grep is run. Only a single FILENAME is allowed to be specified
+  this way.
 
   All options can be set via environment variables, which is most useful if
   you want to override the defaults. Each environment variable

--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -282,8 +282,8 @@ def cli(
     # variables but I can't figure out how to make it work with
     # beangrep's combination of optional pattern and variadic filenames.
     # So we just roll it ourselves.
-    if os.getenv("BEANCOUNT_FILE"):
-        filenames = [os.getenv("BEANCOUNT_FILE")]
+    if os.getenv("BEANCOUNT_FILENAME"):
+        filenames = [os.getenv("BEANCOUNT_FILENAME")]
         if len(args) == 1:
             pattern = args[0]
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,7 +264,7 @@ def test_errors():
 
 # In theory any option could be set via envvars but let's just test the
 # most likely choices
-def test_envvars():
+def test_envvars_options():
     runner = CliRunner()
 
     result = runner.invoke(
@@ -288,3 +288,22 @@ def test_envvars():
         ).exit_code
         == 0
     )
+
+
+def test_envvar_beancount_file():
+    runner = CliRunner()
+
+    assert (
+        runner.invoke(cli, env={"BEANCOUNT_FILE": "does_not_exist.beancount"}).exit_code
+        == 2
+    )
+
+    result = runner.invoke(
+        cli, ["--amount", "=76.81 USD"], env={"BEANCOUNT_FILE": SAMPLE_LEDGER}
+    )
+    assert result.exit_code == 0
+    assert "Verizon Wireless" in result.output
+
+    result = runner.invoke(cli, ["^a-day-in"], env={"BEANCOUNT_FILE": SAMPLE_LEDGER})
+    assert result.exit_code == 0
+    assert "Mercadito" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,16 +294,20 @@ def test_envvar_beancount_file():
     runner = CliRunner()
 
     assert (
-        runner.invoke(cli, env={"BEANCOUNT_FILE": "does_not_exist.beancount"}).exit_code
+        runner.invoke(
+            cli, env={"BEANCOUNT_FILENAME": "does_not_exist.beancount"}
+        ).exit_code
         == 2
     )
 
     result = runner.invoke(
-        cli, ["--amount", "=76.81 USD"], env={"BEANCOUNT_FILE": SAMPLE_LEDGER}
+        cli, ["--amount", "=76.81 USD"], env={"BEANCOUNT_FILENAME": SAMPLE_LEDGER}
     )
     assert result.exit_code == 0
     assert "Verizon Wireless" in result.output
 
-    result = runner.invoke(cli, ["^a-day-in"], env={"BEANCOUNT_FILE": SAMPLE_LEDGER})
+    result = runner.invoke(
+        cli, ["^a-day-in"], env={"BEANCOUNT_FILENAME": SAMPLE_LEDGER}
+    )
     assert result.exit_code == 0
     assert "Mercadito" in result.output


### PR DESCRIPTION
Instead of passing the filename on the command line it can be specified via the BEANCOUNT_FILE environment variable.

The motivation is: with grep having to specify the filename every time is plausible because you're going to run grep on a wide variety of files. With bean-grep (most? all?) people are only going to run bean-grep on a single file, their top-level beancount file. So having to continually specify it is a bit tedious, since in practice that argument will never change.

By allowing the filename to be passed via an environment variable we can bypass that repetition. The general idea is
you could use direnv to set BEANCOUNT_FILE when you enter your beancount directory. Or just set it globally once and for all in your shell configuration file. Then you can simply do

`bean-grep -d 2024-01`
`bean-grep -p Lotus`
`bean-grep -a Vanguard -d 2024-01`