### PR TITLE
Use custom logger (instead of root logger).

### DIFF
--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -277,6 +277,7 @@ def cli(
             log_level = logging.DEBUG
     logger = logging.getLogger(__name__)
     logger.setLevel(log_level)
+    logging.basicConfig(level=log_level)
 
     (pattern, filenames) = (None, [])
     # click has has support for setting arguments via environment

--- a/src/beangrep/cli.py
+++ b/src/beangrep/cli.py
@@ -275,7 +275,8 @@ def cli(
             log_level = logging.INFO
         case _:  # >= 2
             log_level = logging.DEBUG
-    logging.basicConfig(level=log_level)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
 
     (pattern, filenames) = (None, [])
     # click has has support for setting arguments via environment
@@ -321,8 +322,8 @@ def cli(
         )
     except ValueError as e:
         raise click.UsageError(e.args[0]) from e
-    logging.info("Using search criteria: %s", criteria)
-    logging.info("Invert match is %s", "on" if invert_match else "off")
+    logger.info("Using search criteria: %s", criteria)
+    logger.info("Invert match is %s", "on" if invert_match else "off")
 
     match_found = False
     for filename in filenames:
@@ -330,30 +331,30 @@ def cli(
             # Beancount does not support streaming reading, so to mimic Unix filter
             # semantics we read stdin to the end and store it to a temporary file.
             with NamedTemporaryFile(prefix="beangrep.", suffix=".beancount") as tmpfile:
-                logging.info(
+                logger.info(
                     'Buffering standard input to temporary file "%s"...', tmpfile.name
                 )
                 shutil.copyfileobj(sys.stdin.buffer, tmpfile.file)
                 tmpfile.flush()
-                logging.info('Loading entries from file "%s"...', tmpfile.name)
+                logger.info('Loading entries from file "%s"...', tmpfile.name)
                 ledger = beancount.loader.load_file(tmpfile.name)
         else:
-            logging.info('Loading entries from file "%s"...', filename)
+            logger.info('Loading entries from file "%s"...', filename)
             ledger = beancount.loader.load_file(filename)
 
         if ledger[1]:  # Beancount encountered loading error(s), warn user
-            logging.warning(
+            logger.warning(
                 'Beancount encountered %d error(s) when loading file "%s"',
                 len(ledger[1]),
                 filename,
             )
-            logging.info(
+            logger.info(
                 "Beancount errors:\n" + "\n".join(str(err) for err in ledger[1])
             )
         if not ledger[0]:  # No (valid) entries in journal, fail
             ctx.fail(f'No valid entries found in file "{filename}"')
         else:
-            logging.debug(
+            logger.debug(
                 'Loaded %d (valid) entries from file "%s"', len(ledger[0]), filename
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -323,6 +323,7 @@ def test_verbose_logging_info(caplog):
     # broke the logging configuration somehow.
     assert len(caplog.records) > 0
 
+    # 
     for record in caplog.records:
         assert record.levelno == logging.INFO
 
@@ -340,6 +341,10 @@ def test_verbose_logging_debug(caplog):
     # generated but if we don't get ANYTHING then we probably
     # broke the logging configuration somehow.
     assert len(caplog.records) > 0
+
+    # Check that we got at least one DEBUG (i.e. not just all
+    # INFO via some misconfiguration of logging)
+    assert logging.DEBUG in [r.levelno for r in caplog.records]
 
     for record in caplog.records:
         assert record.levelno in (logging.DEBUG, logging.INFO)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from test_beangrep import SAMPLE_LEDGER, SAMPLE_LEDGER_SMALL
 
 from beangrep import cli
+import logging
 
 
 def test_basic():
@@ -311,3 +312,37 @@ def test_envvar_beancount_file():
     )
     assert result.exit_code == 0
     assert "Mercadito" in result.output
+
+
+def test_verbose_logging_info(caplog):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--verbose", "--amount", "25.67", SAMPLE_LEDGER])
+
+    # We don't want to assume too much about the debugging info
+    # generated but if we don't get ANYTHING then we probably
+    # broke the logging configuration somehow.
+    assert len(caplog.records) > 0
+
+    for record in caplog.records:
+        assert record.levelno == logging.INFO
+
+    assert result.exit_code == 0
+    assert "Goba Goba" in result.output
+
+
+def test_verbose_logging_debug(caplog):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["--verbose", "--verbose", "--amount", "25.67", SAMPLE_LEDGER]
+    )
+
+    # We don't want to assume too much about the debugging info
+    # generated but if we don't get ANYTHING then we probably
+    # broke the logging configuration somehow.
+    assert len(caplog.records) > 0
+
+    for record in caplog.records:
+        assert record.levelno in (logging.DEBUG, logging.INFO)
+
+    assert result.exit_code == 0
+    assert "Goba Goba" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -323,7 +323,6 @@ def test_verbose_logging_info(caplog):
     # broke the logging configuration somehow.
     assert len(caplog.records) > 0
 
-    # 
     for record in caplog.records:
         assert record.levelno == logging.INFO
 


### PR DESCRIPTION
This fixes #17 which (I assume) was caused by click's CliRunner configuring the root logger in its own way before beangrep ran.

Our custom logger is "beangrep.cli" (i.e. just __name__ from cli.py). Includes some unit tests to ensure it works as expected.